### PR TITLE
Add 10-servo control with EEPROM storage

### DIFF
--- a/ArduinoServos2.2.json
+++ b/ArduinoServos2.2.json
@@ -5,10 +5,10 @@
     "device": {
         "name": "VentilationArduinoServo",
         "id": "arduino_modbus_slave",
-        "min_read_registers": 2,
+        "min_read_registers": 10,
         "max_read_registers": 10,
         "frame_timeout_ms": 100,
-         "guard_interval_us": 500,
+        "guard_interval_us": 500,
         "groups": [
             {
                 "title": "General",
@@ -17,10 +17,8 @@
             {
                 "title": "HW Info",
                 "id": "hw_info"
-            },
-            
+            }
         ],
-
         "parameters": {
             "baud_rate": {
                 "title": "Baud rate",
@@ -29,75 +27,31 @@
                 "reg_type": "holding",
                 "enum": [96, 192, 384, 576, 1152],
                 "default": 96,
-                "enum_titles": [
-                    "9600",
-                    "19200",
-                    "38400",
-                    "57600",
-                    "115200"
-                ],
+                "enum_titles": ["9600", "19200", "38400", "57600", "115200"],
                 "group": "general",
                 "order": 1
-            },
-            
+            }
         },
-
         "channels": [
-       
-
-            {
-                "name": "Kitchen",
-                "reg_type": "holding",
-                "address": 0,
-                "type": "range",
-                "max": 100,
-                "group": "general"
-            },
-            {
-                "name": "Cabinet",
-                "reg_type": "holding",
-                "address": 1,
-                "type": "range",
-                "max": 100,
-                "group": "general"
-            },
-            {
-                "name": "Badroom",
-                "reg_type": "holding",
-                "address": 2,
-                "type": "range",
-                "max": 100,
-                "group": "general"
-            },
-            {
-                "name": "Living room",
-                "reg_type": "holding",
-                "address": 3,
-                "type": "range",
-                "max": 100,
-                "group": "general"
-            },
-            {
-                "name": "Kid room",
-                "reg_type": "holding",
-                "address": 4,
-                "type": "range",
-                "max": 100,
-                "group": "general"
-            },
-            
-
-            
+            {"name": "Kitchen_out", "reg_type": "holding", "address": 0, "type": "range", "max": 100, "group": "general"},
+            {"name": "Cabinet_out", "reg_type": "holding", "address": 1, "type": "range", "max": 100, "group": "general"},
+            {"name": "Badroom_out", "reg_type": "holding", "address": 2, "type": "range", "max": 100, "group": "general"},
+            {"name": "Living_out", "reg_type": "holding", "address": 3, "type": "range", "max": 100, "group": "general"},
+            {"name": "Kid_out", "reg_type": "holding", "address": 4, "type": "range", "max": 100, "group": "general"},
+            {"name": "Kitchen_in", "reg_type": "holding", "address": 5, "type": "range", "max": 100, "group": "general"},
+            {"name": "Cabinet_in", "reg_type": "holding", "address": 6, "type": "range", "max": 100, "group": "general"},
+            {"name": "Badroom_in", "reg_type": "holding", "address": 7, "type": "range", "max": 100, "group": "general"},
+            {"name": "Living_in", "reg_type": "holding", "address": 8, "type": "range", "max": 100, "group": "general"},
+            {"name": "Kid_in", "reg_type": "holding", "address": 9, "type": "range", "max": 100, "group": "general"}
         ],
         "translations": {
             "en": {
                 "arduino_title": "VentilationArduinoServo",
                 "Current": "Load current"
-        },
+            },
             "ru": {
                 "General": "Общее",
-                "HW Info": "Данные модуля",
-           
+                "HW Info": "Данные модуля"
             }
         }
     }

--- a/VentilationArduinoServo2_3_copy_20240507140830/VentilationArduinoServo2_3_copy_20240507140830.ino
+++ b/VentilationArduinoServo2_3_copy_20240507140830/VentilationArduinoServo2_3_copy_20240507140830.ino
@@ -1,141 +1,41 @@
-#include <Adafruit_PWMServoDriver.h>
-#include <ServoDriverSmooth.h>
+#include <ModbusRtu.h>
 #include <ServoSmooth.h>
-#include <smoothUtil.h>
 #include <EEPROM.h>
 
-//RS-485 Modbus Slave (Arduino UNO)
-//Circuit Digest
-#include<ModbusRtu.h>       //Library for using Modbus in Arduino
-#include <Servo.h>          //Library for using Servo Motor
+const uint8_t servoCount = 10;
+const uint8_t servoPins[servoCount] = {8, 9, 10, 11, 12, A0, A1, A2, A3, A4};
 
+ServoSmooth servos[servoCount];
+Modbus bus;
 
-ServoSmooth servo0; 
-ServoSmooth servo1;   
-ServoSmooth servo2;   
-ServoSmooth servo3;   
-ServoSmooth servo4;     
+const int EEPROM_ADDRESS = 0; // base address for stored servo angles
+uint16_t modbus_array[servoCount];
+uint16_t servoValues[servoCount];
 
-                    //Initilize servo object for class Servo
-Modbus bus;   
-const int arraySize = 2;         //Столько же, сколько адресов             
-const int EEPROM_ADDRESS = 0;// Адрес в EEPROM, где хранится массив
-uint16_t modbus_array[arraySize];    //первоначально в массив записываем нулевые значения
-//uint32_t tmr1;        //таймер  
-//unsigned long sec = millis();; 
+void setup() {
+  for (uint8_t i = 0; i < servoCount; i++) {
+    servos[i].attach(servoPins[i], 100, 2500);
+    servos[i].setSpeed(50);
+    servos[i].setAccel(0.1);
 
-void setup()
-{
-
-  // Считываем массив из EEPROM
-  for (int i = 0; i < arraySize; i++) {
-    modbus_array[i] = EEPROM.read(EEPROM_ADDRESS + i);
-  };
-
-  //Servo0 setup
-  servo0.attach(9, 450, 2200); //для  futaba s3003
-  servo0.setSpeed(50);   // ограничить скорость
-  servo0.setAccel(0.1);  	// установить ускорение (разгон и торможение)
-  //Servo 0 end settup
-
-  //Servo1 setup
-  servo1.attach(8, 200, 2000); //для BMS-620
-  servo1.setSpeed(50);   // ограничить скорость
-  servo1.setAccel(0.1);  	// установить ускорение (разгон и торможение)
-  //Servo 1 end settup
-
-  //Servo2 setup
-  servo2.attach(7, 450, 2250);
-  servo2.setSpeed(50);   // ограничить скорость
-  servo2.setAccel(0.1);  	// установить ускорение (разгон и торможение)
-  //Servo 2 end settup
-
-  //Servo3 setup
-  servo3.attach(6, 450, 2250);
-  servo3.setSpeed(50);   // ограничить скорость
-  servo3.setAccel(0.1);  	// установить ускорение (разгон и торможение)
-  //Servo 3 end settup
-
-  //Servo4 setup
-  servo4.attach(5, 450, 2250);
-  servo4.setSpeed(50);   // ограничить скорость
-  servo4.setAccel(0.1);  	// установить ускорение (разгон и торможение)
-  //Servo 4 end settup
- 
- bus = Modbus(128,1,2);          //адрес ведомого равен 128, используется связь через интерфейс RS-485 (вторая 1), 10 – номер контакта Arduino, к которому подключены контакты DE & RE модуля RS-485
-  bus.begin(9600);                //Modbus slave baudrate at 9600 (скорость 9600 бод)
-}
-void loop()
-{
-
-   bus.poll(modbus_array,sizeof(modbus_array)/sizeof(modbus_array[0]));  //Used to receive or write value from Master 
-    // Сохраняем массив в EEPROM
-for (int b = 0; b < arraySize; b++)
-{
-
-if (EEPROM.read(EEPROM_ADDRESS +b) != modbus_array[b])
-{
-  EEPROM.update(EEPROM_ADDRESS + b, modbus_array[b]);
-Serial.print(modbus_array[b]);
-Serial.println(""); 
-}
-else {};
-} //for
-
- //else
-//Вывод данных для дебага
-// Serial.print("Channel 0-> ");
- //Serial.print(modbus_array[0]);
-//Serial.println(""); 
- //   Serial.print("Channel 1-> ");
- // Serial.print(modbus_array[1]);
- // Serial.println(""); 
-
- //   Serial.print("Channel 2-> ");
-  //Serial.print(modbus_array[2]);
- // Serial.println(""); 
-
- //   Serial.print("Channel 3-> ");
- // Serial.print(modbus_array[3]);
- // Serial.println(""); 
-
-   // Serial.print("Channel 4-> ");
-  //Serial.print(modbus_array[4]);
-  //Serial.println(""); 
-//Вывод данных для дебага
-   
-//Запуск серв
-servo0.tick();     
-servo1.tick();
-servo2.tick();
-servo3.tick();
-servo4.tick();
-
-//Записываем данные регистров в значение переменной (умножаем 100 на 1.8 чтобы получить градусы)
-   int pwms0 = modbus_array[0]*1.8; //Depends upon value in modbus_array[1] written by Master Modbus
-   int pwms1 = modbus_array[1]*1.8; //Depends upon value in modbus_array[1] written by Master Modbus
-   int pwms2 = modbus_array[2]*1.8; //Depends upon value in modbus_array[1] written by Master Modbus
-   int pwms3 = modbus_array[3]*1.8; //Depends upon value in modbus_array[1] written by Master Modbus
-   int pwms4 = modbus_array[4]*1.8; //Depends upon value in modbus_array[1] written by Master Modbus
-  
-
-
-
-
-//Попытка чтобы сервы попорачивались по очереди
-//if (millis() >= sec +10000) {
- //servo0.setTargetDeg(pwms0); 
-//Serial.print("Serv 0->");
-//Serial.println(""); 
- //    sec = millis(); 
- // } else { }
-
-
-//Поворачиваем сервы на установленный угол
- servo0.setTargetDeg(pwms0);  
- servo1.setTargetDeg(pwms1); 
- servo2.setTargetDeg(pwms2); 
- servo3.setTargetDeg(pwms3); 
- servo4.setTargetDeg(pwms4);    	
-
+    servoValues[i] = EEPROM.read(EEPROM_ADDRESS + i);
+    modbus_array[i] = servoValues[i];
+    servos[i].setTargetDeg(servoValues[i] * 1.8);
   }
+
+  bus = Modbus(128, 1, 2); // slave address 128, RS-485 DE/RE on pin D2
+  bus.begin(9600);
+}
+
+void loop() {
+  bus.poll(modbus_array, servoCount);
+
+  for (uint8_t i = 0; i < servoCount; i++) {
+    if (modbus_array[i] != servoValues[i]) {
+      servoValues[i] = modbus_array[i];
+      EEPROM.update(EEPROM_ADDRESS + i, servoValues[i]);
+      servos[i].setTargetDeg(servoValues[i] * 1.8);
+    }
+    servos[i].tick();
+  }
+}


### PR DESCRIPTION
## Summary
- simplify sketch and drop unused libraries
- control 10 servos (5 exhaust D8–D12, 5 intake A0–A4) with unified settings
- store and restore servo angles from EEPROM
- update Wirenboard template for 10 channels

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno VentilationArduinoServo2_3_copy_20240507140830` *(fails: Platform 'arduino:avr' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cbe4ff14832a95aae31ae2890956